### PR TITLE
Fix Electron ESM error

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,6 @@
-// electron/main.js
-const { app, BrowserWindow, Menu, dialog, shell, ipcMain } = require('electron');
-const path = require('path');
+import { app, BrowserWindow, Menu, dialog, shell, ipcMain } from 'electron';
+import path from 'path';
+
 const isDev = process.env.NODE_ENV === 'development';
 const isMac = process.platform === 'darwin';
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,4 @@
-// electron/preload.js
-const { contextBridge, ipcRenderer } = require('electron');
+import { contextBridge, ipcRenderer } from 'electron';
 
 // Expose any needed APIs to the renderer process
 contextBridge.exposeInMainWorld('electron', {
@@ -52,3 +51,5 @@ window.addEventListener('DOMContentLoaded', () => {
   // Any initialization that needs to happen after DOM is loaded
   console.log('DOM fully loaded and parsed - Pora is running with Electron ' + process.versions.electron);
 });
+
+export default contextBridge;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "electron:preview": "npm run build && NODE_ENV=production electron electron/main.js",
     "build:dmg": "npm run electron:build -- --mac dmg"
   },
-  "main": "electron/main.js",
+  "main": "electron/main.cjs",
   "dependencies": {
     "@floating-ui/react": "^0.27.8",
     "@tiptap/extension-highlight": "^2.11.9",


### PR DESCRIPTION
Update `electron/main.js` and `electron/preload.js` to use ES module syntax.

* Replace `require` statements with `import` statements in `electron/main.js`.
* Replace `require` statements with `import` statements in `electron/preload.js`.
* Add `export default contextBridge` at the end of `electron/preload.js`.
* Update `main` field in `package.json` to point to `electron/main.cjs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/espora-net/baobab/pull/8?shareId=2b79bba3-b808-4073-883e-ae6c377314c0).